### PR TITLE
utils: ビルドしたモジュールを /lib/modules に配置して再起動後も残るようにする

### DIFF
--- a/utils/build_install_header_from_apt_raspi2.bash
+++ b/utils/build_install_header_from_apt_raspi2.bash
@@ -11,7 +11,9 @@ rm Makefile
 ln -s Makefile.header_from_apt Makefile
 make clean
 make
-sudo insmod rtmouse.ko
+sudo install -D -m 644 rtmouse.ko /lib/modules/$(uname -r)/extra/rtmouse.ko
+sudo depmod -a
+sudo modprobe rtmouse
 
 # initialize the driver
 sleep 1

--- a/utils/build_install_header_from_apt_raspi4.bash
+++ b/utils/build_install_header_from_apt_raspi4.bash
@@ -13,7 +13,9 @@ make clean
 # Update for Raspberry Pi 4
 sed -i -e "s/#define RASPBERRYPI 2/#define RASPBERRYPI 4/g" rtmouse.c
 make
-sudo insmod rtmouse.ko
+sudo install -D -m 644 rtmouse.ko /lib/modules/$(uname -r)/extra/rtmouse.ko
+sudo depmod -a
+sudo modprobe rtmouse
 
 # initialize the driver
 sleep 1

--- a/utils/build_install_header_from_source_raspi2.bash
+++ b/utils/build_install_header_from_source_raspi2.bash
@@ -11,7 +11,9 @@ rm Makefile
 ln -s Makefile.header_from_source Makefile
 make clean
 make 
-sudo insmod rtmouse.ko
+sudo install -D -m 644 rtmouse.ko /lib/modules/$(uname -r)/extra/rtmouse.ko
+sudo depmod -a
+sudo modprobe rtmouse
 
 # initialize the driver
 sleep 1

--- a/utils/build_install_header_from_source_raspi4.bash
+++ b/utils/build_install_header_from_source_raspi4.bash
@@ -13,7 +13,9 @@ make clean
 # Update for Raspberry Pi 4
 sed -i -e "s/#define RASPBERRYPI 2/#define RASPBERRYPI 4/g" rtmouse.c
 make 
-sudo insmod rtmouse.ko
+sudo install -D -m 644 rtmouse.ko /lib/modules/$(uname -r)/extra/rtmouse.ko
+sudo depmod -a
+sudo modprobe rtmouse
 
 # initialize the driver
 sleep 1


### PR DESCRIPTION
## 問題

`utils/build_install_*.bash` の 4 本は、いずれも同じ形で終わっています。

```bash
make
sudo insmod rtmouse.ko
```

`insmod` はビルドディレクトリからモジュールを直接ロードするだけで、インストールは
しません。そのため `/lib/modules/$(uname -r)` に `rtmouse.ko` は置かれず、
`modprobe rtmouse` は機能しません。

結果として、起動時にドライバをロードする仕組みは**毎回モジュールをコンパイルし直す**
ことになります。Raspberry Pi 4 では 1 回の起動あたり数分の CPU 時間です。
Ubuntu 22.04 / カーネル `5.15.0-1098-raspi` の実機で、`raspicat_setup_scripts` の
`raspicat.service` が起動のたびに `build_install_header_from_apt_raspi4.bash` へ
入り直しているのを確認しました。

もう 1 つ、小さい問題があります。モジュールが既にロード済みのとき `insmod` は
`File exists` で失敗します。これらのスクリプトはすべて `set -e` の下で動くため、
再実行すると途中で異常終了します。

## 変更内容

```bash
 make
-sudo insmod rtmouse.ko
+sudo install -D -m 644 rtmouse.ko /lib/modules/$(uname -r)/extra/rtmouse.ko
+sudo depmod -a
+sudo modprobe rtmouse
```

4 つのバリアント（`apt` / `source` × `raspi2` / `raspi4`）すべてに同じ変更を入れ、
挙動をそろえています。`extra/` はツリー外モジュールの慣例的な置き場で、
`make modules_install` が使う場所と同じです。`depmod -a` により `modprobe` から
解決できるようになります。`modprobe` でロードすることで、再実行しても
問題なく通るようになります。

## 動作確認

上記の実機でビルドとインストールを行いました。

```
$ modinfo -F vermagic /lib/modules/5.15.0-1098-raspi/extra/rtmouse.ko
5.15.0-1098-raspi SMP preempt mod_unload modversions aarch64
```

この状態で `modprobe rtmouse` はコンパイルなしにドライバをロードし、
`/dev/rtmotor0` や `/dev/rtlightsensor0` などもこれまでどおり生成されます。

## この PR に含めていないもの

`src/drivers/Makefile` の `install:` ターゲットは `50-rtmouse.rules` を
`/etc/udev/rules.d/` にコピーしますが、これを呼ぶ箇所がどこにもありません。
そのため、これらのスクリプトはロードのたびに `sudo chmod 666 /dev/rt*` を
必要としています。ここまで入れると変更の趣旨が変わるため別件としましたが、
この PR に含めたほうがよければ対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3ZzEzNKDxANptPX4QNnHn
